### PR TITLE
Update INSTALL.md to include libabsl-dev

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,11 +22,11 @@ This guide walks you through getting `ns3-ntn-toolkit` from a fresh checkout to 
 sudo apt update
 sudo apt install -y build-essential cmake ninja-build git python3 python3-pip \
     libboost-all-dev libgsl-dev libxml2-dev libsqlite3-dev libpcap-dev \
-    pybind11-dev libprotobuf-dev protobuf-compiler \
+    pybind11-dev libprotobuf-dev protobuf-compiler libabsl-dev \
     g++-11 gcc-11
 ```
 
-(`pybind11-dev` and the protobuf packages are needed by the `ns3-ai-ntn`
+(`pybind11-dev`, `libabsl-dev` and the protobuf packages are needed by the `ns3-ai-ntn`
 bridge; everything else is the standard ns-3 toolchain.)
 
 ### Python deps (only needed if you'll use the RL bridge or rebuild figures)


### PR DESCRIPTION
Added `libabsl-dev` to the installation instructions for the ns3-ai-ntn bridge because `./ns3 build` is complaining about missing header `absl/time/time.h` in `ns3-ai-ntn` module.