### PR TITLE
Substitute  to

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,18 @@ if(${NS3_CCACHE})
   endif()
 endif()
 
+# Substitute `ns3/traffic-module.h` to `ns3/ntn-traffic-module.h`
+# Since `ns3-ntn-toolkit` uses 'ntn-traffic' instead of 'traffic'
+# in module and file names
+execute_process(
+  COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/add-ntn-suffix.sh
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  RESULT_VARIABLE ntn_suffix_rc
+)
+if(NOT ntn_suffix_rc EQUAL 0)
+  message(WARNING "add-ntn-suffix.sh exited with code ${ntn_suffix_rc}")
+endif()
+
 # ##############################################################################
 # Process options                     #
 # ##############################################################################

--- a/add-ntn-suffix.sh
+++ b/add-ntn-suffix.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+mapfile -t files < <(grep -rIl 'ns3/traffic-module.h' contrib 2>/dev/null || true)
+if ((${#files[@]})); then
+  sed -i 's|ns3/traffic-module.h|ns3/ntn-traffic-module.h|g' "${files[@]}"
+fi


### PR DESCRIPTION
## Why

Compilation fails because `ns3/traffic-module.h` does not exist, but `ns3/ntn-traffic-module.h`. Apparently, `ns3-ntn-toolkit` seems to have renamed `traffic` module to `ntn-trafifc` and also renamed related files.

## What & How

I created a shell script `add-ntn-suffix.sh`, which finds a pattern `ns3/traffic-module.h` under `contrib/` directory and substitutes it with `ns3/ntn-traffic-module.h`. This shell script is invoked during configuration staged (`./ns3 configure`). So developer experience will be the same.
