### PR TITLE
Add instructions to link missing libraries

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -62,6 +62,16 @@ cd ..
 
 Without this, `ntn-cho`, `oran-ntn`, and `thz-ntn` will silently fail to register.
 
+After pulling the upstream `satellite` module, add the following libraries to `contrib/satellite/CMakeLists.txt`:
+
+```diff
+     ${libconfig-store}
++    ${libmagister-stats}
++    ${libntn-traffic}
++    ${libpoint-to-point}
+   TEST_SOURCES ${test_sources}
+```
+
 ---
 
 ## 4. (Optional) clone the standalone module repos

--- a/README.md
+++ b/README.md
@@ -448,6 +448,17 @@ cd ns3-ntn-toolkit
 
 # 2. Pull SNS3 satellite (REQUIRED — not bundled, ~3.7 GB with TLE data)
 cd contrib/ && git clone https://github.com/sns3/sns3-satellite.git satellite && cd ..
+```
+
+2-1. Add the following libraries to `contrib/satellite/CMakeLists.txt`:
+
+```diff
+     ${libconfig-store}
++    ${libmagister-stats}
++    ${libntn-traffic}
++    ${libpoint-to-point}
+   TEST_SOURCES ${test_sources}
+```
 
 # 3. Configure & build (~15 min on a modern laptop)
 ./ns3 configure --enable-examples --enable-tests
@@ -455,6 +466,7 @@ cd contrib/ && git clone https://github.com/sns3/sns3-satellite.git satellite &&
 
 # 4. Run the integrated multi-module example
 ./ns3 run "ntn-tn-integrated-analysis --algorithm=tte-aware --simTime=10 --numTnUes=4"
+find contrib -type f -exec sed -i 's|ns3/traffic-module.h|ns3/ntn-traffic-module.h|g' {} +
 
 # 5. (Optional) Bring up the observability stack
 cd contrib/ntn-observability/docker && docker compose up -d

--- a/README.md
+++ b/README.md
@@ -466,7 +466,6 @@ cd contrib/ && git clone https://github.com/sns3/sns3-satellite.git satellite &&
 
 # 4. Run the integrated multi-module example
 ./ns3 run "ntn-tn-integrated-analysis --algorithm=tte-aware --simTime=10 --numTnUes=4"
-find contrib -type f -exec sed -i 's|ns3/traffic-module.h|ns3/ntn-traffic-module.h|g' {} +
 
 # 5. (Optional) Bring up the observability stack
 cd contrib/ntn-observability/docker && docker compose up -d


### PR DESCRIPTION
## Why

`ns3-ntn-toolkit` uses `magister-stats`, `ntn-traffic` and `point-to-point` in addition to `sns3-satellite`'s original dependencies. However, they have not been configured to be linked properly

## What & How

Update `README.md` and `INSTALL.md` to instruct a developer to modify `contrib/satellite/CMakeLists.txt` so that those libraries get linked properly.
